### PR TITLE
Change read retrieve to use gp35

### DIFF
--- a/app/backend/approaches/chatgptread.py
+++ b/app/backend/approaches/chatgptread.py
@@ -19,6 +19,7 @@ class ChatGPTReadApproach(Approach):
         else:
             system_prompt = prompt_override
         
+        ## Use the "ChatCompletions" format for the input prompt messages.
         messages = [
             {"role": "system", "content": f"{system_prompt}"},
         ]

--- a/app/backend/approaches/chatgptread.py
+++ b/app/backend/approaches/chatgptread.py
@@ -11,9 +11,18 @@ class ChatGPTReadApproach(Approach):
 
         ## add a system prompt to the messages
         ## then convert the input history to the chat/completions "messages" format
+        
+        ## if the systme override for the prompt is set, use that for the ssytem prompt. Otherwise, use the default
+        prompt_override = overrides.get("prompt_template")
+        if prompt_override is None:
+            system_prompt = "You are an AI chatbot that responds to whatever the user says."
+        else:
+            system_prompt = prompt_override
+        
         messages = [
-            {"role": "system", "content": "You are an AI chatbot that responds to whatever the user says. You must always speak like a pirate, regardless of what has happened in the conversation so far."},
+            {"role": "system", "content": f"{system_prompt}"},
         ]
+
         for utterance_dict in history:
             ## check if the user key exists in the dict
             if "user" in utterance_dict:

--- a/app/backend/approaches/chatgptread.py
+++ b/app/backend/approaches/chatgptread.py
@@ -12,7 +12,7 @@ class ChatGPTReadApproach(Approach):
         ## add a system prompt to the messages
         ## then convert the input history to the chat/completions "messages" format
         
-        ## if the systme override for the prompt is set, use that for the ssytem prompt. Otherwise, use the default
+        ## if the system override for the prompt is set, use that for the system prompt. Otherwise, use the default
         prompt_override = overrides.get("prompt_template")
         if prompt_override is None:
             system_prompt = "You are an AI chatbot that responds to whatever the user says."


### PR DESCRIPTION
## Purpose
Against issue #13. Takes the prompt override from the UI and adds it to the system prompt. Removes the pirate talk. 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* clone branch and run start.sh / start.ps1 to test locally. 
* click on ChatGPT in UI
* Send a message
* Add the prompt override in the UI. Click "Close"
* Send a new message and see if it responds. 
```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->